### PR TITLE
Use assertFalse for negative assertions

### DIFF
--- a/src.test/com/sanwaf/core/AaSimpleTest.java
+++ b/src.test/com/sanwaf/core/AaSimpleTest.java
@@ -27,7 +27,7 @@ public class AaSimpleTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI("/sanwaf-AaSimpleTest.xml");
     request.addParameter("estring_DETECT_ALL", "sDETECTALL");
-    assertTrue(!sanwaf.isThreatDetected(request, true, true));
+    assertFalse(sanwaf.isThreatDetected(request, true, true));
     String s = Sanwaf.getDetects(request);
     assertTrue(s != null && s.contains("\"item\":{\"name\":\"estring_DETECT_ALL\""));
     assertTrue(GetAllErrorsTest.getItemCount(s, "\"item\":{\"name\":\"") == 1);

--- a/src.test/com/sanwaf/core/AttributesTest.java
+++ b/src.test/com/sanwaf/core/AttributesTest.java
@@ -34,7 +34,7 @@ public class AttributesTest {
     request.addParameter("numericdelimited", "aaaaaaaaaa");
     request.addParameter("numericdelimited", "bbbbbbbbbb");
     boolean threat = sanwaf.isThreatDetected(request);
-    assertTrue(!threat);
+    assertFalse(threat);
     resetSanwafAtts();
   }
 
@@ -47,7 +47,7 @@ public class AttributesTest {
     request.addParameter("numericdelimited", "aaaaaaaaaa");
     request.addParameter("numericdelimited", "bbbbbbbbbb");
     boolean threat = sanwaf.isThreatDetected(request);
-    assertTrue(!threat);
+    assertFalse(threat);
     resetSanwafAtts();
   }
 

--- a/src.test/com/sanwaf/core/EndpointsTest.java
+++ b/src.test/com/sanwaf/core/EndpointsTest.java
@@ -35,7 +35,7 @@ public class EndpointsTest {
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("char", "a");
     Boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -56,7 +56,7 @@ public class EndpointsTest {
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("endpointRegex", "foo@bar.com");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
   }
 
   @Test
@@ -66,19 +66,19 @@ public class EndpointsTest {
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("max-min-value", "10");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("max-min-value", "100");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("max-min-value", "20");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -102,7 +102,7 @@ public class EndpointsTest {
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("max-min-value", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -117,7 +117,7 @@ public class EndpointsTest {
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("required", "a");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -132,7 +132,7 @@ public class EndpointsTest {
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("open", "(123) 456-7890 abz ABZ");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
   }
 
   @Test
@@ -141,13 +141,13 @@ public class EndpointsTest {
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("format", "(123) 456-7890 abz ABZ");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("format", "(123) 456-7890 zba ZBA");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -237,7 +237,7 @@ public class EndpointsTest {
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("format", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -254,14 +254,14 @@ public class EndpointsTest {
     request.addParameter("related-simple-child", "aaa");
     request.addParameter("related-simple-parent", "aaa");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("related-simple-child", "aaa");
     request.addParameter("related-simple-parent", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -279,28 +279,28 @@ public class EndpointsTest {
     request.addParameter("related-invalid-child", "aaa");
     request.addParameter("related-invalid-parent", "aaa");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("related-invalid-child", "aaa");
     request.addParameter("related-invalid-parent", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("related-invalid-child", "");
     request.addParameter("related-invalid-parent", "aaa");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/invalid-uri/test.jsp");
     request.addParameter("related-invalid-child", "");
     request.addParameter("related-invalid-parent", "aaa");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     // related-invalidX-child<related>(related-invalidX1-parent)(related-invalidX2-parent)</related>
     request = new MockHttpServletRequest();
@@ -308,7 +308,7 @@ public class EndpointsTest {
     request.addParameter("related-invalidX-child", "");
     request.addParameter("related-invalidX1-parent", "aaa");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
   }
 
   @Test
@@ -329,7 +329,7 @@ public class EndpointsTest {
     request.addParameter("related-equals-child", "aaa");
     request.addParameter("related-equals-parent", "aaa");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -401,7 +401,7 @@ public class EndpointsTest {
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("related-simple-or-no-parent-child", "");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -415,7 +415,7 @@ public class EndpointsTest {
     request.addParameter("related-simple-or-no-parent-child", "abcdefg");
     request.addParameter("related-simple-or-no-parent-parent", "Yes");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
   }
 
   @Test
@@ -426,14 +426,14 @@ public class EndpointsTest {
     request.addParameter("related-simple-or-child", "aaa");
     request.addParameter("related-simple-or-parent", "aaa");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("related-simple-or-child", "aaa");
     request.addParameter("related-simple-or-parent", "bbb");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -454,7 +454,7 @@ public class EndpointsTest {
     request.addParameter("related-simple-or-child", "aaa");
     request.addParameter("related-simple-or-parent", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
   }
 
   @Test
@@ -466,7 +466,7 @@ public class EndpointsTest {
     request.addParameter("related-or-parent1", "aaa");
     request.addParameter("related-or-parent2", "ccc");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -474,7 +474,7 @@ public class EndpointsTest {
     request.addParameter("related-or-parent1", "bbb");
     request.addParameter("related-or-parent2", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -482,7 +482,7 @@ public class EndpointsTest {
     request.addParameter("related-or-parent1", "");
     request.addParameter("related-or-parent2", "ccc");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -506,7 +506,7 @@ public class EndpointsTest {
     request.addParameter("related-or-parent1", "");
     request.addParameter("related-or-parent2", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -514,7 +514,7 @@ public class EndpointsTest {
     request.addParameter("related-or-parent1", "");
     request.addParameter("related-or-parent2", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
   }
 
   @Test
@@ -527,7 +527,7 @@ public class EndpointsTest {
     request.addParameter("related-and-or-parent2", "ccc");
     request.addParameter("related-and-or-parent3", "eee");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -536,7 +536,7 @@ public class EndpointsTest {
     request.addParameter("related-and-or-parent2", "");
     request.addParameter("related-and-or-parent3", "eee");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -563,7 +563,7 @@ public class EndpointsTest {
     request.addParameter("related-and-or-parent2", "");
     request.addParameter("related-and-or-parent3", "eee");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -572,7 +572,7 @@ public class EndpointsTest {
     request.addParameter("related-and-or-parent2", "");
     request.addParameter("related-and-or-parent3", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -581,7 +581,7 @@ public class EndpointsTest {
     request.addParameter("related-and-or-parent2", "ccc");
     request.addParameter("related-and-or-parent3", "");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     // related-and-or-childX<related>(related-and-or-parentX1:aaa||bbb)&&(related-and-or-parentX2:ccc||ddd)||(related-and-or-parentX3:eee||fff)||(related-and-or-parentX4)</related>
     request = new MockHttpServletRequest();
@@ -635,7 +635,7 @@ public class EndpointsTest {
     request.addParameter("parm1", "aaa");
     request.addParameter("parm2", "aaa");
     boolean isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/strictTrue.jsp");
@@ -650,7 +650,7 @@ public class EndpointsTest {
     request.addParameter("parm2", "aaa");
     request.addParameter("parm3", "aaa");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/strictTrue.jsp");
@@ -668,13 +668,13 @@ public class EndpointsTest {
     request.addParameter("parm3", "aaa");
     request.addParameter("parmEXTRA", "aaa");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/notstrictNoTag.jsp");
     request.addParameter("foobar", "aaa");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/strictWithLess.jsp");
@@ -690,7 +690,7 @@ public class EndpointsTest {
     request.addParameter("parm1", "aaa");
     request.addParameter("parm2", "aaa");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/strictWithLess.jsp");
@@ -698,7 +698,7 @@ public class EndpointsTest {
     request.addParameter("parm2", "aaa");
     request.addParameter("parm3", "aaa");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/strictWithLessWord.jsp");
@@ -714,7 +714,7 @@ public class EndpointsTest {
     request.addParameter("parm1", "aaa");
     request.addParameter("parm2", "aaa");
     isThreat = sanwaf.isThreatDetected(request);
-    assertTrue(!isThreat);
+    assertFalse(isThreat);
   }
 
 }

--- a/src.test/com/sanwaf/core/GetAllErrorsTest.java
+++ b/src.test/com/sanwaf/core/GetAllErrorsTest.java
@@ -169,7 +169,7 @@ public class GetAllErrorsTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/detect.jsp");
     request.addParameter("estring_DETECT", "sDETECT");
-    assertTrue(!sanwaf.isThreatDetected(request, true, true));
+    assertFalse(sanwaf.isThreatDetected(request, true, true));
     String s = Sanwaf.getDetects(request);
     assertTrue(s != null && s.contains("\"item\":{\"name\":\"estring_DETECT\""));
     assertTrue(getItemCount(s, "\"item\":{\"name\":\"") == 1);
@@ -180,7 +180,7 @@ public class GetAllErrorsTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/detectall.jsp");
     request.addParameter("estring_DETECT_ALL", "sDETECTALL");
-    assertTrue(!sanwaf.isThreatDetected(request, true, true));
+    assertFalse(sanwaf.isThreatDetected(request, true, true));
     String s = Sanwaf.getDetects(request);
     assertTrue(s != null && s.contains("\"item\":{\"name\":\"estring_DETECT_ALL\""));
     assertTrue(getItemCount(s, "\"item\":{\"name\":\"") == 1);

--- a/src.test/com/sanwaf/core/ModeTest.java
+++ b/src.test/com/sanwaf/core/ModeTest.java
@@ -39,25 +39,25 @@ public class ModeTest {
   public void testParameter() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("modeParameter", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
   public void testParameterString() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("modeParameterString", "javascript: ");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("modeParameterString", "javascript: <script> ");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
   public void testParameterRegex() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("modeParameterRegex", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -73,7 +73,7 @@ public class ModeTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameter-DISABLED", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -89,12 +89,12 @@ public class ModeTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameter-DETECT-BLOCK", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameterString-DETECT-DISABLED", "javascript: <script> ");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -104,14 +104,14 @@ public class ModeTest {
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameterRegex-BLOCK-DISABLED", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
   public void testHeader() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader("modeHeader", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -125,14 +125,14 @@ public class ModeTest {
   public void testHeaderNoModeLargeValue() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("modeParameter-DETECT2", ":RULE-IS-DETECT<script> 12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
   public void testCookie() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setCookies(new Cookie("modeCookie", "foobarfoobar"));
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -147,26 +147,26 @@ public class ModeTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameter-DETECT", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
     String s = Sanwaf.getDetects(request);
     assertTrue(s != null && s.contains("modeeParameter-DETECT"));
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameterString-DETECT", "javascript: <script> ");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameterRegex-DETECT", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameter-DETECT", "foobarfoobar");
     request.addParameter("modeeParameterString", "javascript: <script> ");
     request.addParameter("modeeParameterRegex-DETECT", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -182,7 +182,7 @@ public class ModeTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameter-DISABLED", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -198,12 +198,12 @@ public class ModeTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameter-DETECT-BLOCK", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameterString-DETECT-DISABLED", "javascript: <script> ");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
@@ -213,55 +213,55 @@ public class ModeTest {
     request = new MockHttpServletRequest();
     request.setRequestURI("/foo/bar/test.jsp");
     request.addParameter("modeeParameterRegex-BLOCK-DISABLED", "foobarfoobar");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
   public void testDatatypeDetect() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("char", "cc");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("numeric", "abc");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("numericdelimited", "abc");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("alphanumeric", "!@#$");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("alphanumericandmore", "!!@$#$");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("constant", "abc");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("regex", "abc");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("endpointRegex", "abc");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("max-min-value", "abclkajdflkjasdklfjaskldfjaskldfjlkasjflkasjflkasdjfklasjfklasdjflkasdjfk");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("format", "abc");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("dependentparent", "123");
     request.addParameter("dependentformat", "<script>abc23@!##");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
     String s = Sanwaf.getDetects(request);
     assertTrue(s != null && s.length() > 0);
 
@@ -271,14 +271,14 @@ public class ModeTest {
   public void testTest() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("numericdelimited", "abc");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
   public void testRegexModeDetextNoModeOnParmDetect() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("regexParmNoModeWithRegexDetectMode", "abcd");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
 }

--- a/src.test/com/sanwaf/core/ReduceXmlTest.java
+++ b/src.test/com/sanwaf/core/ReduceXmlTest.java
@@ -36,7 +36,7 @@ public class ReduceXmlTest {
     request = new MockHttpServletRequest();
     request.addParameter("Numeric", "12345");
     result = sanwaf.isThreatDetected(request);
-    assertTrue(!result);
+    assertFalse(result);
   }
 }
 

--- a/src.test/com/sanwaf/core/RegexMatchFlagTest.java
+++ b/src.test/com/sanwaf/core/RegexMatchFlagTest.java
@@ -29,7 +29,7 @@ public class RegexMatchFlagTest {
   public void testStringMatchPass() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("stringMatchPass", "javascript:");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -45,7 +45,7 @@ public class RegexMatchFlagTest {
     // <item><name>customMatchPass</name><type>r{date-MatchPass}</type></item>
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("customMatchPass", "416-555-5555");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -53,7 +53,7 @@ public class RegexMatchFlagTest {
     // <item><name>customNoMatch</name><type>r{date-NoMatch}</type></item>
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("customNoMatch", "416-555-5555");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 }
 

--- a/src.test/com/sanwaf/core/RegexUsingFilesTest.java
+++ b/src.test/com/sanwaf/core/RegexUsingFilesTest.java
@@ -33,7 +33,7 @@ public class RegexUsingFilesTest {
 
     request = new MockHttpServletRequest();
     request.addParameter("regex1", "123-456-7890");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -44,7 +44,7 @@ public class RegexUsingFilesTest {
 
     request = new MockHttpServletRequest();
     request.addParameter("regex2", "123-456-7890");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
   @Test
@@ -55,7 +55,7 @@ public class RegexUsingFilesTest {
 
     request = new MockHttpServletRequest();
     request.addParameter("string", "123456");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
   }
 
 }

--- a/src.test/com/sanwaf/core/SanwafChildShieldTest.java
+++ b/src.test/com/sanwaf/core/SanwafChildShieldTest.java
@@ -38,7 +38,7 @@ public class SanwafChildShieldTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addParameter("String", "javascript: should pass short string has no javascript: test");
     Boolean result = sanwaf.isThreatDetected(request);
-    assertTrue(!result);
+    assertFalse(result);
   }
 
   @Test
@@ -53,7 +53,7 @@ public class SanwafChildShieldTest {
   public void testIsThreatNoMaxViolation() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, IOException {
     String value = "javascript: should pass short string has no javascript: test";
     Boolean result = sanwaf.isThreat(value);
-    assertTrue(!result);
+    assertFalse(result);
   }
 
   @Test

--- a/src.test/com/sanwaf/core/SanwafIsThreatTest.java
+++ b/src.test/com/sanwaf/core/SanwafIsThreatTest.java
@@ -39,7 +39,7 @@ public class SanwafIsThreatTest {
   @Test
   public void testThreatWithNull() {
     boolean b = sanwaf.isThreat(null);
-    assertTrue(!b);
+    assertFalse(b);
   }
 
   @Test

--- a/src.test/com/sanwaf/core/SanwafTest.java
+++ b/src.test/com/sanwaf/core/SanwafTest.java
@@ -163,7 +163,7 @@ public class SanwafTest {
     boolean xssAlways = shield.regexAlways;
     shield.regexAlways = true;
     boolean b = sanwaf.isThreatDetected(null);
-    assertTrue(!b);
+    assertFalse(b);
 
     MockHttpServletRequest request = new MockHttpServletRequest();
     request = new MockHttpServletRequest();

--- a/src.test/com/sanwaf/core/StringRegexMixedBlockDetectTest.java
+++ b/src.test/com/sanwaf/core/StringRegexMixedBlockDetectTest.java
@@ -36,11 +36,11 @@ public class StringRegexMixedBlockDetectTest {
 
     request = new MockHttpServletRequest();
     request.addParameter("string", "DETECT");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
     request = new MockHttpServletRequest();
     request.addParameter("string", "DETECT_ALL");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 }
 
   @Test
@@ -56,7 +56,7 @@ public class StringRegexMixedBlockDetectTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request = new MockHttpServletRequest();
     request.addParameter("string", "DETECT_ALL DETECT DETECT_ALL DETECT");
-    assertTrue(!sanwaf.isThreatDetected(request));
+    assertFalse(sanwaf.isThreatDetected(request));
 
   }
 

--- a/src.test/com/sanwaf/core/VerboseTest.java
+++ b/src.test/com/sanwaf/core/VerboseTest.java
@@ -36,14 +36,14 @@ public class VerboseTest {
   public void verboseDisabledTest() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, IOException {
     sanwaf = new Sanwaf(new UnitTestLogger(), "/sanwaf.xml");
     String s = outContent.toString();
-    assertTrue(!s.contains("Settings:"));
-    assertTrue(!s.contains("RegexAlways=true"));
-    assertTrue(!s.contains("Shield Secured List: *Ignored*"));
-    assertTrue(!s.contains("Except for (exclusion list):"));
-    assertTrue(!s.contains("StringRegexs:"));
-    assertTrue(!s.contains("customPatterns:"));
-    assertTrue(!s.contains("Configured/Secured Entries:"));
-    assertTrue(!s.contains("customPatterns"));
+    assertFalse(s.contains("Settings:"));
+    assertFalse(s.contains("RegexAlways=true"));
+    assertFalse(s.contains("Shield Secured List: *Ignored*"));
+    assertFalse(s.contains("Except for (exclusion list):"));
+    assertFalse(s.contains("StringRegexs:"));
+    assertFalse(s.contains("customPatterns:"));
+    assertFalse(s.contains("Configured/Secured Entries:"));
+    assertFalse(s.contains("customPatterns"));
   }
 
   @Test
@@ -51,7 +51,7 @@ public class VerboseTest {
     sanwaf = new Sanwaf(new UnitTestLogger(), "/sanwaf-verbose.xml");
     String s = outContent.toString();
     assertTrue(s.contains("Settings:"));
-    assertTrue(!s.contains("RegexAlways=true"));
+    assertFalse(s.contains("RegexAlways=true"));
     assertTrue(s.contains("StringRegexs:"));
     assertTrue(s.contains("customPatterns:"));
     assertTrue(s.contains("Secured Items:"));
@@ -65,7 +65,7 @@ public class VerboseTest {
       sanwaf = new Sanwaf(new UnitTestLogger(), "/sanwaf-forceRegex.xml");
       MockHttpServletRequest request = new MockHttpServletRequest();
       request.addParameter("modeParameter", "foobarfoobar");
-      assertTrue(!sanwaf.isThreatDetected(request));
+      assertFalse(sanwaf.isThreatDetected(request));
 
       request = new MockHttpServletRequest();
       request.addParameter("xxxx", "<script>");
@@ -82,7 +82,7 @@ public class VerboseTest {
     assertTrue(s.contains("forceStringPatterns=true"));
     assertTrue(s.contains("Shield Secured List: *Ignored*"));
     assertTrue(s.contains("Except for (exclusion list):"));
-    assertTrue(!s.contains("Configured/Secured Entries:"));
+    assertFalse(s.contains("Configured/Secured Entries:"));
     assertTrue(s.contains("customPatterns"));
     assertTrue(s.contains("date="));
   }


### PR DESCRIPTION
## Summary
- cleanup assertions in tests to use `assertFalse` for negative conditions

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a87dad398832ba9419c800d620f5d